### PR TITLE
Fix cross compile to macOS

### DIFF
--- a/muduo/net/SocketsOps.cc
+++ b/muduo/net/SocketsOps.cc
@@ -115,7 +115,7 @@ void sockets::listenOrDie(int sockfd)
 int sockets::accept(int sockfd, struct sockaddr_in6* addr)
 {
   socklen_t addrlen = static_cast<socklen_t>(sizeof *addr);
-#if VALGRIND || defined (NO_ACCEPT4)
+#if VALGRIND || defined (NO_ACCEPT4) || defined (__MACH__)
   int connfd = ::accept(sockfd, sockaddr_cast(addr), &addrlen);
   setNonBlockAndCloseOnExec(connfd);
 #else


### PR DESCRIPTION
_update v1: update stacktrace_

```cpp
FAILED: contrib/muduo-cmake/net/CMakeFiles/_muduo_net.dir/__/__/muduo/muduo/net/SocketsOps.cc.o 
/usr/bin/ccache /usr/bin/clang++-16 --target=x86_64-apple-darwin -DBOOST_ASIO_HAS_STD_INVOKE_RESULT=1 -DBOOST_ASIO_STANDALONE=1 -DHAS_RESERVED_IDENTIFIER -D_LIBCPP_ENABLE_THREAD_SAFETY_ANNOTATIONS -I/proton_testing_build/contrib/muduo/muduo/net -isystem /proton_testing_build/contrib/muduo -isystem /proton_testing_build/contrib/llvm-project/libcxx/include -isystem /proton_testing_build/contrib/llvm-project/libcxxabi/include -isystem /proton_testing_build/contrib/boost -std=c++20 -fdiagnostics-color=always -Xclang -fuse-ctor-homing -Wno-enum-constexpr-conversion -fsized-deallocation  -gdwarf-aranges -pipe -mssse3 -msse4.1 -msse4.2 -mpclmul -mpopcnt -fasynchronous-unwind-tables -ffile-prefix-map=/proton_testing_build=. -falign-functions=32 -mbranches-within-32B-boundaries   -Wall -Wno-unused-command-line-argument  -stdlib=libc++ -fdiagnostics-absolute-paths -fstrict-vtable-pointers -w -O2 -g -DNDEBUG -O3 -g -gdwarf-4  -isysroot /proton_testing_build/cmake/darwin/../toolchain/darwin-x86_64 -mmacosx-version-min=10.15   -D OS_DARWIN -Werror -nostdinc++ -std=gnu++2b -MD -MT contrib/muduo-cmake/net/CMakeFiles/_muduo_net.dir/__/__/muduo/muduo/net/SocketsOps.cc.o -MF contrib/muduo-cmake/net/CMakeFiles/_muduo_net.dir/__/__/muduo/muduo/net/SocketsOps.cc.o.d -o contrib/muduo-cmake/net/CMakeFiles/_muduo_net.dir/__/__/muduo/muduo/net/SocketsOps.cc.o -c /proton_testing_build/contrib/muduo/muduo/net/SocketsOps.cc
/proton_testing_build/contrib/muduo/muduo/net/SocketsOps.cc:122:18: error: no member named 'accept4' in the global namespace
  int connfd = ::accept4(sockfd, sockaddr_cast(addr),
               ~~^
/proton_testing_build/contrib/muduo/muduo/net/SocketsOps.cc:123:36: error: use of undeclared identifier 'SOCK_NONBLOCK'
                         &addrlen, SOCK_NONBLOCK | SOCK_CLOEXEC);
                                   ^
/proton_testing_build/contrib/muduo/muduo/net/SocketsOps.cc:123:52: error: use of undeclared identifier 'SOCK_CLOEXEC'
                         &addrlen, SOCK_NONBLOCK | SOCK_CLOEXEC);
                                                   ^
3 errors generated.
```